### PR TITLE
feat: 데모페이지 UI

### DIFF
--- a/src/components/RankCard.tsx
+++ b/src/components/RankCard.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { ButtonText } from '../styles/Typography';
+import Box from '@mui/material/Box';
+import { Button } from '@mui/material';
+import { Headline, Title, Body } from '../styles/Typography';
+
+interface RankCardProps {
+  title: string;
+  description: string;
+  rank: number;
+  votes: number;
+  width?: string;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>; //(e: MouseEvent<Element, MouseEvent>) => void
+}
+const RankCard: React.FC<RankCardProps> = ({
+  title,
+  description,
+  rank,
+  votes,
+  onClick,
+  width,
+}) => {
+  return (
+    <Box
+      sx={{
+        width: width ? width : '100%',
+        maxWidth: '800px',
+        backgroundColor: 'primary.white',
+        border: '2px solid ',
+        borderColor: 'primary.main',
+        borderRadius: '20px',
+        display: 'flex',
+        justifyContent: 'space-around',
+        alignItems: 'center',
+      }}
+    >
+      <Rank rank={rank} />
+      <Headline inherit>{title}</Headline>
+      <Body>{description}</Body>
+      <Headline color="var(--ceos-blue-color)">{votes}</Headline>
+    </Box>
+  );
+};
+
+const Rank = ({ rank }: { rank: number }) => {
+  return (
+    <Box
+      sx={{
+        width: '50px',
+        height: '50px',
+        backgroundColor: 'primary.main',
+        borderRadius: '10px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: 'white',
+      }}
+    >
+      <Title inherit>{rank} </Title>
+    </Box>
+  );
+};
+
+export default RankCard;

--- a/src/components/SizedBox.tsx
+++ b/src/components/SizedBox.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function SizedBox({ width, height }: { width?: any; height?: any }) {
+  return <div style={{ width, height }}></div>;
+}
+
+export default SizedBox;

--- a/src/pages/Demo/DemoCard.tsx
+++ b/src/pages/Demo/DemoCard.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Button } from '@mui/material';
+import { Headline, Title, Body } from '../../styles/Typography';
+
+interface DemoCardProps {
+  title: string;
+  description: string;
+  selected?: boolean;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>; //(e: MouseEvent<Element, MouseEvent>) => void
+}
+const DemoCard: React.FC<DemoCardProps> = ({
+  selected,
+  title,
+  description,
+  onClick,
+}) => {
+  const defaultStyle = {
+    width: '350px',
+    height: '120px',
+    border: '2px solid ',
+    borderRadius: '20px',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  };
+
+  const selectedStyle = {
+    width: '350px',
+    height: '120px',
+    border: '2px solid ',
+    borderRadius: '20px',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'primary.main',
+    '&:hover': {
+      //you want this to be the same as the backgroundColor above
+      backgroundColor: 'primary.main',
+    },
+    color: 'white',
+  };
+  return (
+    <Button sx={selected ? selectedStyle : defaultStyle} onClick={onClick}>
+      <Title inherit>{title}</Title>
+      <Body inherit>{description}</Body>
+    </Button>
+  );
+};
+
+export default DemoCard;

--- a/src/pages/Demo/DemoMainPage.tsx
+++ b/src/pages/Demo/DemoMainPage.tsx
@@ -1,7 +1,31 @@
 import React from 'react';
 
+import MainBtn from '../../components/MainBtn';
+import { Headline } from '../../styles/Typography';
+import { Box } from '@mui/material';
+import SizedBox from '../../components/SizedBox';
+import { useNavigate } from 'react-router-dom';
 const DemoMainPage = () => {
-  return <div>데모데이 투표 메인 페이지</div>;
+  const navigate = useNavigate();
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        gap: '50px',
+      }}
+    >
+      <Headline>데모데이 투표 </Headline>
+      <SizedBox height={'20px'} />
+      <MainBtn onClick={() => navigate('/demo/vote')}>투표하기</MainBtn>
+      <MainBtn onClick={() => navigate('/demo/result')}>결과보기</MainBtn>
+    </Box>
+  );
 };
 
 export default DemoMainPage;

--- a/src/pages/Demo/DemoResultPage.tsx
+++ b/src/pages/Demo/DemoResultPage.tsx
@@ -1,6 +1,72 @@
 import React from 'react';
+import { Box } from '@mui/material';
+import { Headline } from '../../styles/Typography';
+import RankCard from '../../components/RankCard';
+import MainBtn from '../../components/MainBtn';
+import { useNavigate } from 'react-router-dom';
+
 const DemoResultPage = () => {
-  return <div>데모데이 투표 결과 페이지</div>;
+  const navigate = useNavigate();
+
+  const services = [
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+      rank: 1,
+      votes: 5,
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+      rank: 2,
+      votes: 4,
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+      rank: 3,
+      votes: 3,
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+      rank: 4,
+      votes: 2,
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+      rank: 5,
+      votes: 1,
+    },
+  ];
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        width: '100%',
+        overflowY: 'scroll',
+        gap: '10px',
+        justifyContent: 'space-around',
+        alignItems: 'center',
+      }}
+    >
+      <Headline>데모데이 투표 결과</Headline>
+      {services.map(({ title, description, rank, votes }) => (
+        <RankCard
+          key={title}
+          title={title}
+          description={description}
+          rank={rank}
+          votes={votes}
+        />
+      ))}
+
+      <MainBtn onClick={() => navigate('/demo')}>돌아가기</MainBtn>
+    </Box>
+  );
 };
 
 export default DemoResultPage;

--- a/src/pages/Demo/DemoVotePage.tsx
+++ b/src/pages/Demo/DemoVotePage.tsx
@@ -1,6 +1,83 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Headline } from '../../styles/Typography';
+import { Box } from '@mui/material';
+import MainBtn from '../../components/MainBtn';
+import DemoCard from './DemoCard';
+import { useNavigate } from 'react-router-dom';
 const DemoVotePage = () => {
-  return <div>데모데이 투표창 페이지</div>;
+  const navigate = useNavigate();
+  const [selected, setSelected] = useState(0);
+  const services = [
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+    },
+  ];
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        gap: '50px',
+      }}
+    >
+      <Headline>데모데이 투표</Headline>
+      <Box
+        sx={{
+          width: '80%',
+
+          display: 'flex',
+          flexWrap: 'wrap',
+          flexDirection: 'row',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: '40px',
+        }}
+      >
+        {services.map(({ title, description }, idx) => (
+          <DemoCard
+            key={title}
+            title={title}
+            description={description}
+            onClick={() => setSelected(idx)}
+            selected={idx == selected}
+          />
+        ))}
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: '10px',
+        }}
+      >
+        <MainBtn>투표하기</MainBtn>
+        <MainBtn onClick={() => navigate('/demo/result')}>결과보기</MainBtn>
+      </Box>
+    </Box>
+  );
 };
 
 export default DemoVotePage;

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { Headline } from '../../styles/Typography';
 import SelectBtn from '../../components/SelectBtn';
 import { Box } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 const MainPage = () => {
+  const navigate = useNavigate();
   return (
     <Box
       sx={{
@@ -28,11 +30,11 @@ const MainPage = () => {
       >
         <SelectBtn
           title="파트장 투표 바로가기"
-          onClick={() => console.log('click')}
+          onClick={() => navigate('/part')}
         />
         <SelectBtn
           title="데모데이 투표바로가기"
-          onClick={() => console.log('click')}
+          onClick={() => navigate('/demo')}
         />
       </Box>
     </Box>

--- a/src/styles/Typography.tsx
+++ b/src/styles/Typography.tsx
@@ -34,6 +34,21 @@ const ButtonText = styled.span<FontProps>`
   margin: 0;
 `;
 
+const Title = styled.span<FontProps>`
+  font-family: 'Inter';
+  font-style: normal;
+
+  font-weight: ${({ weight }) => (weight ? weight : 600)};
+  font-size: ${({ size }) => (size ? size : '2.3rem')};
+  color: ${({ color }) => (color ? color : `#000000`)};
+  ${({ inherit }) =>
+    inherit &&
+    css`
+      color: inherit;
+    `}
+  margin: 0;
+`;
+
 const CustomFont = styled.span<FontProps>`
   font-family: 'Inter';
   font-style: normal;
@@ -49,13 +64,18 @@ const CustomFont = styled.span<FontProps>`
 const Body = styled.span<FontProps>`
   font-family: 'Inter';
   font-style: normal;
-  font-weight: ${({ weight }) => (weight ? weight : 500)};
-  font-size: ${({ size }) => (size ? size : '1.5rem')};
-  color: ${({ color }) => (color ? color : `var(--black)`)};
-  margin: 0;
 
+  font-weight: ${({ weight }) => (weight ? weight : 500)};
+  font-size: ${({ size }) => (size ? size : '1rem')};
+  color: ${({ color }) => (color ? color : `#000000`)};
+  margin: 0;
+  ${({ inherit }) =>
+    inherit &&
+    css`
+      color: inherit;
+    `}
   line-height: 24px;
   letter-spacing: -0.022em;
 `;
 
-export { Headline, ButtonText, CustomFont, Body };
+export { Headline, ButtonText, CustomFont, Body, Title };

--- a/src/styles/Typography.tsx
+++ b/src/styles/Typography.tsx
@@ -76,6 +76,7 @@ const Body = styled.span<FontProps>`
     `}
   line-height: 24px;
   letter-spacing: -0.022em;
+  white-space: nowrap;
 `;
 
 export { Headline, ButtonText, CustomFont, Body, Title };


### PR DESCRIPTION
## 작업 내용
- 데모 메인 페이지
- 데모 투표 페이지
- 데모 결과 페이지

## 스크린샷


- 데모 메인 페이지
![image](https://github.com/TherapEase-CEOS/react-vote-17th/assets/86418674/41d953cf-aa60-4cca-806a-e625e376a883)
- 데모 투표 페이지
![image](https://github.com/TherapEase-CEOS/react-vote-17th/assets/86418674/856df517-223e-46c8-8417-3b0daa3dc885)

- 데모 결과 페이지
![image](https://github.com/TherapEase-CEOS/react-vote-17th/assets/86418674/c659518e-c698-4111-bee8-7bd37eced883)

## 전달 사항

- Component 폴더에 RankCard Component 를 생성하였습니다. 
width props를 주어서 크기를 조절할 수 있는데, 파트장 투표 결과화면에서도 재사용하면 좋을 것 같습니다! 
![image](https://github.com/TherapEase-CEOS/react-vote-17th/assets/86418674/2721da00-de4d-4fe7-97ce-d6bea7f49625)
