### PR TITLE
feat: 파트장 투표 화면 UI 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["build", "dist", "public"]
+}

--- a/src/components/MainBtn.tsx
+++ b/src/components/MainBtn.tsx
@@ -13,9 +13,9 @@ const MainBtn: React.FC<ButtonProps> = ({ children, onClick }) => {
   return (
     <Button
       sx={{
-        width: '250px',
-        height: '70px',
-        borderRadius: '20px',
+        width: '220px',
+        height: '50px',
+        borderRadius: '10px',
       }}
       onClick={onClick}
       variant="contained"

--- a/src/components/RankCard.tsx
+++ b/src/components/RankCard.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { ButtonText } from '../styles/Typography';
+import Box from '@mui/material/Box';
+import { Button } from '@mui/material';
+import { Headline, Title, Body } from '../styles/Typography';
+
+interface RankCardProps {
+  title: string;
+  description: string;
+  rank: number;
+  votes: number;
+  width?: string;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>; //(e: MouseEvent<Element, MouseEvent>) => void
+}
+const RankCard: React.FC<RankCardProps> = ({
+  title,
+  description,
+  rank,
+  votes,
+  onClick,
+  width,
+}) => {
+  return (
+    <Box
+      sx={{
+        width: width ? width : '100%',
+        maxWidth: '800px',
+        backgroundColor: 'primary.white',
+        border: '2px solid ',
+        borderColor: 'primary.main',
+        borderRadius: '20px',
+        display: 'flex',
+        justifyContent: 'space-around',
+        alignItems: 'center',
+      }}
+    >
+      <Rank rank={rank} />
+      <Headline inherit>{title}</Headline>
+      <Body>{description}</Body>
+      <Headline color="var(--ceos-blue-color)">{votes}</Headline>
+    </Box>
+  );
+};
+
+const Rank = ({ rank }: { rank: number }) => {
+  return (
+    <Box
+      sx={{
+        width: '50px',
+        height: '50px',
+        backgroundColor: 'primary.main',
+        borderRadius: '10px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: 'white',
+      }}
+    >
+      <Title inherit>{rank} </Title>
+    </Box>
+  );
+};
+
+export default RankCard;

--- a/src/components/SelectBtn.tsx
+++ b/src/components/SelectBtn.tsx
@@ -13,8 +13,8 @@ const SelectBtn: React.FC<SelectBtnProps> = ({ title, onClick }) => {
   return (
     <Button
       sx={{
-        width: '350px',
-        height: '350px',
+        width: '320px',
+        height: '320px',
         backgroundColor: 'primary.white',
         border: '2px solid ',
         borderColor: 'primary.main',

--- a/src/components/SizedBox.tsx
+++ b/src/components/SizedBox.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function SizedBox({ width, height }: { width?: any; height?: any }) {
+  return <div style={{ width, height }}></div>;
+}
+
+export default SizedBox;

--- a/src/constants/dummyData.ts
+++ b/src/constants/dummyData.ts
@@ -10,3 +10,16 @@ export const DUMMY_MEMBERS = [
   { teamName: 'Repick', userName: '이예지' },
   { teamName: 'Repick', userName: '배성준' },
 ];
+
+export const DUMMY_PART_VOTE_RESULT = [
+  { teamName: 'TherapEase', userName: '권가은', voteCount: 5 },
+  { teamName: 'TherapEase', userName: '김서연', voteCount: 5 },
+  { teamName: 'bariBari', userName: '오예린', voteCount: 5 },
+  { teamName: 'bariBari', userName: '최민주', voteCount: 5 },
+  { teamName: 'Hooking', userName: '장효신', voteCount: 5 },
+  { teamName: 'Hooking', userName: '김문기', voteCount: 5 },
+  { teamName: 'DanSupport', userName: '노수진', voteCount: 5 },
+  { teamName: 'DanSupport', userName: '신유진', voteCount: 5 },
+  { teamName: 'Repick', userName: '이예지', voteCount: 5 },
+  { teamName: 'Repick', userName: '배성준', voteCount: 5 },
+];

--- a/src/constants/dummyData.ts
+++ b/src/constants/dummyData.ts
@@ -1,0 +1,12 @@
+export const DUMMY_MEMBERS = [
+  { teamName: 'TherapEase', userName: '권가은' },
+  { teamName: 'TherapEase', userName: '김서연' },
+  { teamName: 'bariBari', userName: '오예린' },
+  { teamName: 'bariBari', userName: '최민주' },
+  { teamName: 'Hooking', userName: '장효신' },
+  { teamName: 'Hooking', userName: '김문기' },
+  { teamName: 'DanSupport', userName: '노수진' },
+  { teamName: 'DanSupport', userName: '신유진' },
+  { teamName: 'Repick', userName: '이예지' },
+  { teamName: 'Repick', userName: '배성준' },
+];

--- a/src/pages/Demo/DemoCard.tsx
+++ b/src/pages/Demo/DemoCard.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Button } from '@mui/material';
+import { Headline, Title, Body } from '../../styles/Typography';
+
+interface DemoCardProps {
+  title: string;
+  description: string;
+  selected?: boolean;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>; //(e: MouseEvent<Element, MouseEvent>) => void
+}
+const DemoCard: React.FC<DemoCardProps> = ({
+  selected,
+  title,
+  description,
+  onClick,
+}) => {
+  const defaultStyle = {
+    width: '350px',
+    height: '120px',
+    border: '2px solid ',
+    borderRadius: '20px',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  };
+
+  const selectedStyle = {
+    width: '350px',
+    height: '120px',
+    border: '2px solid ',
+    borderRadius: '20px',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'primary.main',
+    '&:hover': {
+      //you want this to be the same as the backgroundColor above
+      backgroundColor: 'primary.main',
+    },
+    color: 'white',
+  };
+  return (
+    <Button sx={selected ? selectedStyle : defaultStyle} onClick={onClick}>
+      <Title inherit>{title}</Title>
+      <Body inherit>{description}</Body>
+    </Button>
+  );
+};
+
+export default DemoCard;

--- a/src/pages/Demo/DemoMainPage.tsx
+++ b/src/pages/Demo/DemoMainPage.tsx
@@ -1,7 +1,31 @@
 import React from 'react';
 
+import MainBtn from '../../components/MainBtn';
+import { Headline } from '../../styles/Typography';
+import { Box } from '@mui/material';
+import SizedBox from '../../components/SizedBox';
+import { useNavigate } from 'react-router-dom';
 const DemoMainPage = () => {
-  return <div>데모데이 투표 메인 페이지</div>;
+  const navigate = useNavigate();
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        gap: '50px',
+      }}
+    >
+      <Headline>데모데이 투표 </Headline>
+      <SizedBox height={'20px'} />
+      <MainBtn onClick={() => navigate('/demo/vote')}>투표하기</MainBtn>
+      <MainBtn onClick={() => navigate('/demo/result')}>결과보기</MainBtn>
+    </Box>
+  );
 };
 
 export default DemoMainPage;

--- a/src/pages/Demo/DemoResultPage.tsx
+++ b/src/pages/Demo/DemoResultPage.tsx
@@ -1,6 +1,72 @@
 import React from 'react';
+import { Box } from '@mui/material';
+import { Headline } from '../../styles/Typography';
+import RankCard from '../../components/RankCard';
+import MainBtn from '../../components/MainBtn';
+import { useNavigate } from 'react-router-dom';
+
 const DemoResultPage = () => {
-  return <div>데모데이 투표 결과 페이지</div>;
+  const navigate = useNavigate();
+
+  const services = [
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+      rank: 1,
+      votes: 5,
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+      rank: 2,
+      votes: 4,
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+      rank: 3,
+      votes: 3,
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+      rank: 4,
+      votes: 2,
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+      rank: 5,
+      votes: 1,
+    },
+  ];
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        width: '100%',
+        overflowY: 'scroll',
+        gap: '10px',
+        justifyContent: 'space-around',
+        alignItems: 'center',
+      }}
+    >
+      <Headline>데모데이 투표 결과</Headline>
+      {services.map(({ title, description, rank, votes }) => (
+        <RankCard
+          key={title}
+          title={title}
+          description={description}
+          rank={rank}
+          votes={votes}
+        />
+      ))}
+
+      <MainBtn onClick={() => navigate('/demo')}>돌아가기</MainBtn>
+    </Box>
+  );
 };
 
 export default DemoResultPage;

--- a/src/pages/Demo/DemoVotePage.tsx
+++ b/src/pages/Demo/DemoVotePage.tsx
@@ -1,6 +1,83 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Headline } from '../../styles/Typography';
+import { Box } from '@mui/material';
+import MainBtn from '../../components/MainBtn';
+import DemoCard from './DemoCard';
+import { useNavigate } from 'react-router-dom';
 const DemoVotePage = () => {
-  return <div>데모데이 투표창 페이지</div>;
+  const navigate = useNavigate();
+  const [selected, setSelected] = useState(0);
+  const services = [
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+    },
+    {
+      title: 'FINBLE',
+      description: '주식 관리 포트폴리오 서비스',
+    },
+  ];
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        gap: '50px',
+      }}
+    >
+      <Headline>데모데이 투표</Headline>
+      <Box
+        sx={{
+          width: '80%',
+
+          display: 'flex',
+          flexWrap: 'wrap',
+          flexDirection: 'row',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: '40px',
+        }}
+      >
+        {services.map(({ title, description }, idx) => (
+          <DemoCard
+            key={title}
+            title={title}
+            description={description}
+            onClick={() => setSelected(idx)}
+            selected={idx == selected}
+          />
+        ))}
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: '10px',
+        }}
+      >
+        <MainBtn>투표하기</MainBtn>
+        <MainBtn onClick={() => navigate('/demo/result')}>결과보기</MainBtn>
+      </Box>
+    </Box>
+  );
 };
 
 export default DemoVotePage;

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { Headline } from '../../styles/Typography';
 import SelectBtn from '../../components/SelectBtn';
 import { Box } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 const MainPage = () => {
+  const navigate = useNavigate();
   return (
     <Box
       sx={{
@@ -28,11 +30,11 @@ const MainPage = () => {
       >
         <SelectBtn
           title="파트장 투표 바로가기"
-          onClick={() => console.log('click')}
+          onClick={() => navigate('/part')}
         />
         <SelectBtn
           title="데모데이 투표바로가기"
-          onClick={() => console.log('click')}
+          onClick={() => navigate('/demo')}
         />
       </Box>
     </Box>

--- a/src/pages/Part/PartMainPage.tsx
+++ b/src/pages/Part/PartMainPage.tsx
@@ -1,6 +1,66 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import styled from '@emotion/styled';
+
+import { Headline } from '../../styles/Typography';
+import SelectBtn from '../../components/SelectBtn';
+import MainBtn from '../../components/MainBtn';
+
 const PartMainPage = () => {
-  return <div>파트장 투표 메인 페이지</div>;
+  const navigate = useNavigate();
+
+  const FRONT_TITLE = `FRONT-END\n파트장 투표`;
+  const BACK_TITLE = `BACK-END\n파트장 투표`;
+
+  return (
+    <Container>
+      <Headline>파트장 투표</Headline>
+      <div className="contents-wrapper">
+        <div className="buttons-wrapper-col">
+          <SelectBtn
+            title={FRONT_TITLE}
+            onClick={() => navigate('/part/vote', { state: 'FE' })}
+          />
+          <MainBtn onClick={() => navigate('/part/result', { state: 'FE' })}>
+            결과 보기
+          </MainBtn>
+        </div>
+        <div className="buttons-wrapper-col">
+          <SelectBtn
+            title={BACK_TITLE}
+            onClick={() => navigate('/part/vote', { state: 'BE' })}
+          />
+          <MainBtn onClick={() => navigate('/part/result', { state: 'BE' })}>
+            결과 보기
+          </MainBtn>
+        </div>
+      </div>
+    </Container>
+  );
 };
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .contents-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    margin-top: 40px;
+  }
+
+  .buttons-wrapper-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 0 75px;
+    row-gap: 20px;
+  }
+`;
 
 export default PartMainPage;

--- a/src/pages/Part/PartResultPage.tsx
+++ b/src/pages/Part/PartResultPage.tsx
@@ -1,6 +1,68 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router';
+
+import styled from '@emotion/styled';
+
+import { Headline } from '../../styles/Typography';
+import RankCard from '../../components/RankCard';
+import MainBtn from '../../components/MainBtn';
+
+import { DUMMY_PART_VOTE_RESULT } from '../../constants/dummyData';
+
 const PartResultPage = () => {
-  return <div>파트장 투표 결과 페이지</div>;
+  const navigate = useNavigate();
+  const { state } = useLocation();
+
+  return (
+    <Container>
+      <Headline>{state} 파트장 투표 결과</Headline>
+      <div className="contents-wrapper">
+        <div className="cards-wrapper">
+          {DUMMY_PART_VOTE_RESULT.map(
+            ({ userName, teamName, voteCount }, idx) => {
+              return (
+                <RankCard
+                  key={idx}
+                  title={userName}
+                  description={teamName}
+                  rank={idx}
+                  votes={voteCount}
+                  width="40%"
+                />
+              );
+            }
+          )}
+        </div>
+        <MainBtn onClick={() => navigate(-1)}>돌아가기</MainBtn>
+      </div>
+    </Container>
+  );
 };
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .contents-wrapper {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 40px;
+  }
+
+  .cards-wrapper {
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 25px;
+    margin-bottom: 40px;
+  }
+`;
 
 export default PartResultPage;

--- a/src/pages/Part/PartVoteCard.tsx
+++ b/src/pages/Part/PartVoteCard.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { Button } from '@mui/material';
+import { CustomFont } from '../../styles/Typography';
+
+interface PartVoteCardProps {
+  memberInfo: { teamName: string; userName: string };
+  isSelected: boolean;
+  setSelectedMember: (value: { teamName: string; userName: string }) => void;
+}
+
+const PartVoteCard = ({
+  memberInfo,
+  isSelected,
+  setSelectedMember,
+}: PartVoteCardProps) => {
+  const { teamName, userName } = memberInfo;
+
+  const handleCardClick = () => {
+    if (isSelected) {
+      setSelectedMember({ teamName: '', userName: '' });
+    } else {
+      setSelectedMember(memberInfo);
+    }
+  };
+
+  return (
+    <Button
+      variant="outlined"
+      sx={{
+        width: '180px',
+        height: '100px',
+        display: 'flex',
+        flexDirection: 'column',
+        border: '2px solid',
+        borderRadius: '15px',
+        borderColor: 'primary.main',
+        color: `${isSelected ? 'white' : 'black'}`,
+        backgroundColor: `${isSelected ? 'primary.main' : 'white'}`,
+        '&:hover': {
+          color: 'white',
+        },
+      }}
+      onClick={handleCardClick}
+    >
+      <CustomFont inherit size="0.8rem">{`${teamName}\n`}</CustomFont>
+      <CustomFont
+        inherit
+        weight={700}
+        size="1.3rem"
+      >{`${userName}`}</CustomFont>
+    </Button>
+  );
+};
+
+export default PartVoteCard;

--- a/src/pages/Part/PartVotePage.tsx
+++ b/src/pages/Part/PartVotePage.tsx
@@ -1,6 +1,92 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router';
+
+import styled from '@emotion/styled';
+
+import { Headline } from '../../styles/Typography';
+import PartVoteCard from './PartVoteCard';
+import MainBtn from '../../components/MainBtn';
+
+import { DUMMY_MEMBERS } from '../../constants/dummyData';
+
 const PartVotePage = () => {
-  return <div>파트장 투표창 페이지</div>;
+  const navigate = useNavigate();
+  const { state } = useLocation();
+
+  const [selectedMember, setSelectedMember] = useState<{
+    teamName: string;
+    userName: string;
+  }>({
+    teamName: '',
+    userName: '',
+  });
+
+  const handleVoteSumbit = () => {
+    // TODO - 투표 제출 api
+    console.log(selectedMember);
+  };
+
+  return (
+    <Container>
+      <Headline>{state} 파트장 투표</Headline>
+      <div className="contents-wrapper">
+        <div className="cards-wrapper">
+          {DUMMY_MEMBERS.map((member, idx) => {
+            return (
+              <PartVoteCard
+                key={idx}
+                memberInfo={member}
+                isSelected={
+                  selectedMember.teamName === member.teamName &&
+                  selectedMember.userName === member.userName
+                }
+                setSelectedMember={setSelectedMember}
+              />
+            );
+          })}
+        </div>
+        <div className="buttons-wrapper">
+          <MainBtn onClick={handleVoteSumbit}>투표하기</MainBtn>
+          <MainBtn onClick={() => navigate(`/part/result`, { state: state })}>
+            결과보기
+          </MainBtn>
+        </div>
+      </div>
+    </Container>
+  );
 };
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .contents-wrapper {
+    width: calc(100% - 40px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 40px;
+  }
+
+  .cards-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+
+    button {
+      margin: 20px;
+    }
+  }
+
+  .buttons-wrapper {
+    display: flex;
+    margin-top: 40px;
+    gap: 15px;
+  }
+`;
 
 export default PartVotePage;

--- a/src/styles/Typography.tsx
+++ b/src/styles/Typography.tsx
@@ -4,11 +4,11 @@ import { css } from '@emotion/react';
 interface FontProps {
   weight?: number;
   color?: string;
-  size?: number;
+  size?: string;
   inherit?: boolean;
 }
 
-const Headline = styled.header<FontProps>`
+const Headline = styled.span<FontProps>`
   font-family: 'Inter';
   font-weight: ${({ weight }) => (weight ? weight : 600)};
   font-size: ${({ size }) => (size ? size : '2.5rem')}; // 48px
@@ -25,11 +25,12 @@ const Headline = styled.header<FontProps>`
   text-align: center;
   letter-spacing: -0.022em;
 `;
+
 const ButtonText = styled.span<FontProps>`
   font-family: 'Inter';
   font-style: normal;
   font-weight: ${({ weight }) => (weight ? weight : 500)};
-  font-size: ${({ size }) => (size ? size : '2rem')};
+  font-size: ${({ size }) => (size ? size : '1.1rem')};
   color: ${({ color }) => (color ? color : `#FFFDFD`)};
   margin: 0;
 `;
@@ -40,12 +41,18 @@ const CustomFont = styled.span<FontProps>`
   font-weight: ${({ weight }) => (weight ? weight : 300)};
   font-size: ${({ size }) => (size ? size : '1rem')};
   color: ${({ color }) => (color ? color : `black`)};
+  ${({ inherit }) =>
+    inherit &&
+    css`
+      color: inherit;
+    `}
   margin: 0;
 
   line-height: 150%;
   /* or 38px */
   letter-spacing: -0.022em;
 `;
+
 const Body = styled.span<FontProps>`
   font-family: 'Inter';
   font-style: normal;

--- a/src/styles/Typography.tsx
+++ b/src/styles/Typography.tsx
@@ -4,11 +4,11 @@ import { css } from '@emotion/react';
 interface FontProps {
   weight?: number;
   color?: string;
-  size?: number;
+  size?: string;
   inherit?: boolean;
 }
 
-const Headline = styled.header<FontProps>`
+const Headline = styled.span<FontProps>`
   font-family: 'Inter';
   font-weight: ${({ weight }) => (weight ? weight : 600)};
   font-size: ${({ size }) => (size ? size : '2.5rem')}; // 48px
@@ -25,11 +25,12 @@ const Headline = styled.header<FontProps>`
   text-align: center;
   letter-spacing: -0.022em;
 `;
+
 const ButtonText = styled.span<FontProps>`
   font-family: 'Inter';
   font-style: normal;
   font-weight: ${({ weight }) => (weight ? weight : 500)};
-  font-size: ${({ size }) => (size ? size : '2rem')};
+  font-size: ${({ size }) => (size ? size : '1.1rem')};
   color: ${({ color }) => (color ? color : `#FFFDFD`)};
   margin: 0;
 `;
@@ -55,12 +56,18 @@ const CustomFont = styled.span<FontProps>`
   font-weight: ${({ weight }) => (weight ? weight : 300)};
   font-size: ${({ size }) => (size ? size : '1rem')};
   color: ${({ color }) => (color ? color : `black`)};
+  ${({ inherit }) =>
+    inherit &&
+    css`
+      color: inherit;
+    `}
   margin: 0;
 
   line-height: 150%;
   /* or 38px */
   letter-spacing: -0.022em;
 `;
+
 const Body = styled.span<FontProps>`
   font-family: 'Inter';
   font-style: normal;

--- a/src/styles/Typography.tsx
+++ b/src/styles/Typography.tsx
@@ -34,6 +34,21 @@ const ButtonText = styled.span<FontProps>`
   margin: 0;
 `;
 
+const Title = styled.span<FontProps>`
+  font-family: 'Inter';
+  font-style: normal;
+
+  font-weight: ${({ weight }) => (weight ? weight : 600)};
+  font-size: ${({ size }) => (size ? size : '2.3rem')};
+  color: ${({ color }) => (color ? color : `#000000`)};
+  ${({ inherit }) =>
+    inherit &&
+    css`
+      color: inherit;
+    `}
+  margin: 0;
+`;
+
 const CustomFont = styled.span<FontProps>`
   font-family: 'Inter';
   font-style: normal;
@@ -49,13 +64,18 @@ const CustomFont = styled.span<FontProps>`
 const Body = styled.span<FontProps>`
   font-family: 'Inter';
   font-style: normal;
-  font-weight: ${({ weight }) => (weight ? weight : 500)};
-  font-size: ${({ size }) => (size ? size : '1.5rem')};
-  color: ${({ color }) => (color ? color : `var(--black)`)};
-  margin: 0;
 
+  font-weight: ${({ weight }) => (weight ? weight : 500)};
+  font-size: ${({ size }) => (size ? size : '1rem')};
+  color: ${({ color }) => (color ? color : `#000000`)};
+  margin: 0;
+  ${({ inherit }) =>
+    inherit &&
+    css`
+      color: inherit;
+    `}
   line-height: 24px;
   letter-spacing: -0.022em;
 `;
 
-export { Headline, ButtonText, CustomFont, Body };
+export { Headline, ButtonText, CustomFont, Body, Title };

--- a/src/styles/Typography.tsx
+++ b/src/styles/Typography.tsx
@@ -76,6 +76,7 @@ const Body = styled.span<FontProps>`
     `}
   line-height: 24px;
   letter-spacing: -0.022em;
+  white-space: nowrap;
 `;
 
 export { Headline, ButtonText, CustomFont, Body, Title };

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -105,6 +105,10 @@ video {
   vertical-align: baseline;
 }
 
+span {
+  white-space: pre-wrap;
+}
+
 /* HTML5 display-role reset for older browsers */
 article,
 aside,


### PR DESCRIPTION
## 작업 내용
- https://github.com/TherapEase-CEOS/react-vote-17th/issues/3
  - 기존 컴포넌트 사이즈 조정
  - PartMainPage ui 작업
  - PartVotePage ui 작업
  - PartResultPage ui 작업

## 스크린샷
- PartMainPage
![image](https://github.com/TherapEase-CEOS/react-vote-17th/assets/65700066/a6fd6812-5e6e-43b4-a7bc-1cf7dcade7f4)
![image](https://github.com/TherapEase-CEOS/react-vote-17th/assets/65700066/5d9701b6-a960-49b0-af9e-b27d134e3848)

- PartVotePage
![image](https://github.com/TherapEase-CEOS/react-vote-17th/assets/65700066/8bd1b9f5-2017-49cf-8260-fcd32f661e90)
![image](https://github.com/TherapEase-CEOS/react-vote-17th/assets/65700066/2a1be607-4d87-4019-932d-a6bfff0364da)

- PartResultPage 
![image](https://github.com/TherapEase-CEOS/react-vote-17th/assets/65700066/4180df46-e809-4473-ad4c-d0c2e78b32c5)
![image](https://github.com/TherapEase-CEOS/react-vote-17th/assets/65700066/435b6c28-631a-4eb1-ba91-e7e1ee234c9d)


## 전달 사항
- RankCard 컴포넌트는 로컬에서 복붙해 작업 후 커밋은 하지 않았습니다.
해당 컴포넌트 사이즈 변경 필요할 것 같습니다!
(투표 결과 화면 스크린샷은 화면 75%)
